### PR TITLE
Remove link to mean.js

### DIFF
--- a/en/resources/frameworks.md
+++ b/en/resources/frameworks.md
@@ -17,7 +17,6 @@ Several popular Node.js frameworks are built on Express:
 - **[Poet](http://jsantell.github.io/poet)**: Lightweight Markdown Blog Engine with instant pagination, tag and category views.
 - **[Kraken](http://krakenjs.com/)**: Secure and scalable layer that extends Express by providing structure and convention.
 - **[LoopBack](http://loopback.io)**: Highly-extensible, open-source Node.js framework for quickly creating dynamic end-to-end REST APIs.
-- **[MEAN](https://meanjs.org/)**: Opinionated fullstack JavaScript framework that simplifies and accelerates web application development.
 - **[Sails](http://sailsjs.org/)**: MVC framework for Node.js for building practical, production-ready apps.
 - **[Hydra-Express](https://github.com/flywheelsports/fwsp-hydra-express)**: Hydra-Express is a light-weight library which facilitates building Node.js Microservices using ExpressJS.
 - **[Blueprint](http://github.com/onehilltech/blueprint)**: a SOLID framework for building APIs and backend services


### PR DESCRIPTION
(Didn't see any requirements on naming conventions for commits or PRs to contribute to the docs.  I apologize in advance if I simply missed them.)

Per this Issue on the mean.js repo:

https://github.com/meanjs/mean/issues/2043

... the project is no longer maintained (2-3 years since last updated), the code doesn't work with the latest rev of dependencies, and per a project contributor, it would a significant amount of effort to get a project up and running again.